### PR TITLE
fix: 서버 탭 클래스 수정 및 호버 메시지 순서 조정

### DIFF
--- a/components/server-tab.html
+++ b/components/server-tab.html
@@ -29,13 +29,13 @@
                 >
             </li>
             <li class="server__button">
-                <a class="server__link" href="#" aria-label="서버 추가하기" data-tooltip="서버 추가하기">
+                <button class="server__link button" type="button" aria-label="서버 추가하기" data-tooltip="서버 추가하기">
                     <svg class="server__icon" xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21" fill="none">
                         <path
                             d="M10.5,0.5c-5.5,0-10,4.5-10,10s4.5,10,10,10s10-4.5,10-10S16,0.5,10.5,0.5z M17,11.3h-5.7V17H9.7v-5.7H4V9.7h5.7V4h1.6v5.7H17V11.3z"
                         />
                     </svg>
-                </a>
+                </button>
             </li>
             <li class="server__button">
                 <a class="server__link" href="#" aria-label="찾기" data-tooltip="찾기">

--- a/index.html
+++ b/index.html
@@ -50,9 +50,9 @@
                     >
                 </li>
                 <li class="server__button">
-                    <a
-                        class="server__link"
-                        href="#"
+                    <button
+                        class="server__link button"
+                        type="button"
                         aria-label="서버 추가하기"
                         data-tooltip="서버 추가하기">
                         <svg
@@ -65,7 +65,7 @@
                             <path
                                 d="M10.5,0.5c-5.5,0-10,4.5-10,10s4.5,10,10,10s10-4.5,10-10S16,0.5,10.5,0.5z M17,11.3h-5.7V17H9.7v-5.7H4V9.7h5.7V4h1.6v5.7H17V11.3z" />
                         </svg>
-                    </a>
+                    </button>
                 </li>
                 <li class="server__button">
                     <a

--- a/styles/server-tab.css
+++ b/styles/server-tab.css
@@ -141,6 +141,11 @@
     padding: 0.75rem;
     list-style: none;
 
+    .button {
+        border: none;
+        cursor: pointer;
+    }
+
     .server__radio:first-child {
         padding-bottom: 0.75rem;
         border-bottom: 1px solid var(--color-grey-700);


### PR DESCRIPTION
- profile__img 클래스 제거
- 호버 메시지 프로필 이미지 뒤로 숨어서 z-index로 순서 조정
- 리스트 타입 제거
- 버튼 아이콘 사이즈 키우기
- 상단 여백 추가
- 서버 탭의 최소 높이 지정
- 서버 추가하기 버튼을 a -> button 요소로 수정